### PR TITLE
Detect command improvements

### DIFF
--- a/src/Akeneo/CouplingDetector/Console/Command/DetectCommand.php
+++ b/src/Akeneo/CouplingDetector/Console/Command/DetectCommand.php
@@ -44,12 +44,6 @@ class DetectCommand extends Command
                         InputOption::VALUE_REQUIRED,
                         'file path of the configuration file'
                     ),
-                    new InputOption(
-                        'strict',
-                        null,
-                        InputOption::VALUE_NONE,
-                        'Apply strict rules without legacy exceptions'
-                    ),
                 ]
             )
             ->setDescription('Detect coupling violations')
@@ -134,10 +128,7 @@ HELP
             $configFile = $configDir . DIRECTORY_SEPARATOR . '.php_cd';
         }
 
-        $strictMode = $input->getOption('strict');
-        $output->writeln(
-            sprintf('<info>Detecting coupling violations (strict mode %s)...</info>', $strictMode ? 'enabled' : 'disabled')
-        );
+        $output->writeln('<info>Detecting coupling violations...</info>');
 
         $config = $this->loadConfiguration($configFile);
         $rules = $config->getRules();

--- a/src/Akeneo/CouplingDetector/Console/Command/DetectCommand.php
+++ b/src/Akeneo/CouplingDetector/Console/Command/DetectCommand.php
@@ -41,12 +41,6 @@ class DetectCommand extends Command
                         'file path of the configuration file'
                     ),
                     new InputOption(
-                        'output',
-                        null,
-                        InputOption::VALUE_REQUIRED, 'Output mode, "default", "none"',
-                        'default'
-                    ),
-                    new InputOption(
                         'strict',
                         null,
                         InputOption::VALUE_NONE,
@@ -133,20 +127,12 @@ HELP
             $configFile = $configDir . DIRECTORY_SEPARATOR . '.php_cd';
         }
 
-        $config = $this->loadConfiguration($configFile);
-
         $strictMode = $input->getOption('strict');
-        $displayMode = $input->getOption('output');
+        $output->writeln(
+            sprintf('<info> Detect coupling violations (strict mode %s)</info>', $strictMode ? 'enabled' : 'disabled')
+        );
 
-        if ('none' !== $displayMode) {
-            $output->writeln(
-                sprintf(
-                    '<info> Detect coupling violations (strict mode %s)</info>',
-                    $strictMode ? 'enabled' : 'disabled'
-                )
-            );
-        }
-
+        $config = $this->loadConfiguration($configFile);
         $rules = $config->getRules();
         $finder = $config->getFinder();
         $finder->in($path);
@@ -156,12 +142,9 @@ HELP
         $detector = new CouplingDetector($nodeParserResolver, $ruleChecker);
 
         $violations = $detector->detect($finder, $rules);
+        $this->displayStandardViolations($output, $violations);
 
-        if ('none' !== $displayMode) {
-            $this->displayStandardViolations($output, $violations);
-        }
-
-        return count($violations) > 0 ? 1 : 0;
+        return count($violations);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/akeneo/php-coupling-detector/issues/10

TODO:
- [x] delete *display mode* option
- [x] define an exit status
- [x] rework the ouptut and the verbose mode
- [x] delete *strict* option

new output, verbose enabled
![detect](https://cloud.githubusercontent.com/assets/3691804/11534362/aff4c926-990e-11e5-8d28-9cc7b8391553.png)

