### PR TITLE
Replace "fabpot/php-cs-fixer" by "friendsofphp/php-cs-fixer"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.6",
-        "fabpot/php-cs-fixer": "~1.11",
+        "friendsofphp/php-cs-fixer": "~1.11",
         "symfony/event-dispatcher": "~2.3|~3.0",
         "symfony/finder": "~2.3|~3.0",
         "symfony/console": "~2.3|~3.0",


### PR DESCRIPTION
"fabpot/php-cs-fixer" is deprecated and is not to be used anymore. "friendsofphp/php-cs-fixer" is the official replacement.