### PR TITLE
Update php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.6",
-        "friendsofphp/php-cs-fixer": "^1.11",
+        "friendsofphp/php-cs-fixer": "^2.0",
         "symfony/event-dispatcher": "~2.3|~3.0",
         "symfony/finder": "~2.3|~3.0",
         "symfony/console": "~2.3|~3.0",


### PR DESCRIPTION
We need to upgrade to the new php-cs-fixer 2.x, to have Junit outputs.