### PR TITLE
Improve exception message of ExtractionException

### DIFF
--- a/src/Akeneo/CouplingDetector/NodeParser/NodeParserInterface.php
+++ b/src/Akeneo/CouplingDetector/NodeParser/NodeParserInterface.php
@@ -17,7 +17,7 @@ interface NodeParserInterface
      *
      * @return NodeInterface
      *
-     * @throws ExtractionException
+     * @throws ParsingException
      */
     public function parse(\SplFileInfo $file);
 }

--- a/src/Akeneo/CouplingDetector/NodeParser/ParsingException.php
+++ b/src/Akeneo/CouplingDetector/NodeParser/ParsingException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Akeneo\CouplingDetector\NodeParser;
+
+/**
+ * Class ParsingException.
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+class ParsingException extends \LogicException
+{
+}

--- a/src/Akeneo/CouplingDetector/NodeParser/PhpClassNodeParser.php
+++ b/src/Akeneo/CouplingDetector/NodeParser/PhpClassNodeParser.php
@@ -20,6 +20,9 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 class PhpClassNodeParser implements NodeParserInterface
 {
+    /**
+     * {@inheritdoc}
+     */
     public function parse(\SplFileInfo $file)
     {
         $namespaceExtractor = new NamespaceExtractor();
@@ -28,8 +31,16 @@ class PhpClassNodeParser implements NodeParserInterface
 
         $content = file_get_contents($file->getRealPath());
         $tokens = Tokens::fromCode($content);
-        $classNamespace = $namespaceExtractor->extract($tokens);
-        $className = $classNameExtractor->extract($tokens);
+        try {
+            $classNamespace = $namespaceExtractor->extract($tokens, $file);
+            $className = $classNameExtractor->extract($tokens, $file);
+        } catch (ExtractionException $e) {
+            throw new ParsingException(sprintf(
+                "Parsing exception on \"%s\":\n%s",
+                $file->getPathname(),
+                $e->getMessage()
+            ));
+        }
         $classFullName = sprintf('%s\%s', $classNamespace, $className);
         $useDeclarations = $useDeclarationExtractor->extract($tokens);
 


### PR DESCRIPTION
When there was an issue on ClassNameExtractor or NamespaceExtractor, the Exception does not link to any file.
This PR improve the exception message to include the errored file.