### PR TITLE
Fixed exeptions for unprocessable *.php files:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ cache:
 
 before_script:
   - composer self-update
-  - composer update --prefer-source
 
 script:
     - ./bin/phpspec run

--- a/src/CouplingDetector.php
+++ b/src/CouplingDetector.php
@@ -110,16 +110,16 @@ class CouplingDetector
 
         $nodes = array();
         foreach ($finder as $file) {
-            try {
-                $parser = $this->nodeParserResolver->resolve($file);
-                if (null !== $parser) {
+            $parser = $this->nodeParserResolver->resolve($file);
+            if (null !== $parser) {
+                try {
                     $node = $parser->parse($file);
                     $nodes[] = $node;
                     $this->eventDispatcher->dispatch(Events::NODE_PARSED, new NodeParsedEvent($node));
+                } catch (ExtractionException $e) {
+                    // at the moment, let's just ignore invalid node
+                    // need to fix that with a better design
                 }
-            } catch (ExtractionException $e) {
-                // Ignore unprocessable files
-                continue;
             }
         }
 

--- a/src/CouplingDetector.php
+++ b/src/CouplingDetector.php
@@ -15,6 +15,7 @@ use Akeneo\CouplingDetector\Event\PreNodesParsedEvent;
 use Akeneo\CouplingDetector\Event\PreRulesCheckedEvent;
 use Akeneo\CouplingDetector\Event\RuleCheckedEvent;
 use Akeneo\CouplingDetector\Event\PostRulesCheckedEvent;
+use Akeneo\CouplingDetector\NodeParser\ExtractionException;
 use Akeneo\CouplingDetector\NodeParser\NodeParserResolver;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Finder\Finder;
@@ -109,11 +110,16 @@ class CouplingDetector
 
         $nodes = array();
         foreach ($finder as $file) {
-            $parser = $this->nodeParserResolver->resolve($file);
-            if (null !== $parser) {
-                $node = $parser->parse($file);
-                $nodes[] = $node;
-                $this->eventDispatcher->dispatch(Events::NODE_PARSED, new NodeParsedEvent($node));
+            try {
+                $parser = $this->nodeParserResolver->resolve($file);
+                if (null !== $parser) {
+                    $node = $parser->parse($file);
+                    $nodes[] = $node;
+                    $this->eventDispatcher->dispatch(Events::NODE_PARSED, new NodeParsedEvent($node));
+                }
+            } catch (ExtractionException $e) {
+                // Ignore unprocessable files
+                continue;
             }
         }
 

--- a/src/NodeParser/PhpClassNodeParser.php
+++ b/src/NodeParser/PhpClassNodeParser.php
@@ -42,8 +42,14 @@ class PhpClassNodeParser implements NodeParserInterface
         }
 
         $tokens = Tokens::fromCode($content);
-        $classNamespace = $namespaceExtractor->extract($tokens);
-        $className = $classNameExtractor->extract($tokens);
+        try {
+            $classNamespace = $namespaceExtractor->extract($tokens);
+            $className = $classNameExtractor->extract($tokens);
+        } catch (ExtractionException $e) {
+            throw new ExtractionException(
+                'File is not a class file, ignoring.', null, $e
+            );
+        }
         $classFullName = sprintf('%s\%s', $classNamespace, $className);
         $useDeclarations = $useDeclarationExtractor->extract($tokens);
 

--- a/src/NodeParser/PhpClassNodeParser.php
+++ b/src/NodeParser/PhpClassNodeParser.php
@@ -47,7 +47,7 @@ class PhpClassNodeParser implements NodeParserInterface
             $className = $classNameExtractor->extract($tokens);
         } catch (ExtractionException $e) {
             throw new ExtractionException(
-                'File is not a class file, ignoring.', null, $e
+                'File is not a class file, ignoring.', $e->getCode(), $e
             );
         }
         $classFullName = sprintf('%s\%s', $classNamespace, $className);


### PR DESCRIPTION
The whole process breaks when:
* no class is declared in the file
* no namespace declaration is present in the file (eg. src/AppKernel.php on Sf 3.3+)