### PR TITLE
Fix detect command formatter

### DIFF
--- a/src/Console/Command/DetectCommand.php
+++ b/src/Console/Command/DetectCommand.php
@@ -70,7 +70,7 @@ class DetectCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->setFormatter(new OutputFormatter(true));
+        $output->setFormatter(new OutputFormatter($output->isDecorated()));
 
         if (null !== $format = $this->getFormatOption($input)) {
             if (!in_array($format, $this->formats)) {


### PR DESCRIPTION
This fix let Symfony choose if it has to use the color in the terminal (for grep usage)