### PR TITLE
Display node subject instead of filepath

### DIFF
--- a/src/Formatter/Console/PrettyFormatter.php
+++ b/src/Formatter/Console/PrettyFormatter.php
@@ -83,19 +83,21 @@ class PrettyFormatter extends AbstractFormatter
         $msg = !$this->verbose ?
             sprintf(
                 'Node <comment>%s</comment> does not respect the rule <comment>%s</comment> because of the tokens:',
-                $node->getFilepath(),
+                $node->getSubject(),
                 $rule->getSubject()
             ) :
             sprintf(<<<MSG
 Node <comment>%s</comment> does not respect the rule <comment>%s</comment>:
+    * filepath: %s
     * type: %s
     * description: %s
     * requirements: %s
 The following tokens are wrong:
 MSG
                 ,
-                $node->getFilepath(),
+                $node->getSubject(),
                 $rule->getSubject(),
+                $node->getFilepath(),
                 $rule->getType(),
                 $rule->getDescription() ?: 'N/A',
                 implode(', ', $rule->getRequirements())


### PR DESCRIPTION
When the issues are displayed, show the subject (FQCN in the case of a class) of the failing nodes instead of their filepath.

Before :
![Screenshot from 2019-11-27 18:20:05](https://user-images.githubusercontent.com/659491/69745538-b1fec900-1142-11ea-8007-d90e1ac9f00f.png)

After :
![Screenshot from 2019-11-27 18:21:52](https://user-images.githubusercontent.com/659491/69745639-e07ca400-1142-11ea-9f8d-9ec703bb8545.png)

The filepath can still be found in verbose mode if needed :
![Screenshot from 2019-11-27 18:23:32](https://user-images.githubusercontent.com/659491/69745767-289bc680-1143-11ea-865a-c0429f48428d.png)
