### PR TITLE
Remove blank line in output

### DIFF
--- a/bin/php-coupling-detector
+++ b/bin/php-coupling-detector
@@ -1,5 +1,4 @@
 #!/usr/bin/env php
-
 <?php
 /**
  * @author    Nicolas Dupont <nicolas@akeneo.com>


### PR DESCRIPTION
Not sure if by design, but there's an extra line here before the php tag meaning every time you run php-coupling-detector it outputs a blank line before doing anything e.g.

```
$ bin/php-coupling-detector

Akeneo coupling detector master
```