### PR TITLE
Fix unused requirement command

### DIFF
--- a/spec/RuleBuilderSpec.php
+++ b/spec/RuleBuilderSpec.php
@@ -14,13 +14,6 @@ class RuleBuilderSpec extends ObjectBehavior
         $this->shouldHaveType(RuleBuilder::class);
     }
 
-    function it_does_not_create_a_rule_without_constraints()
-    {
-        $this
-            ->shouldThrow(new \Exception('Can not create a rule without any requirement defined previously.'))
-            ->during('in', ['baz']);
-    }
-
     function it_chains_the_methods_for_building_a_rule()
     {
         $this->forbids(['foo', 'bar'])->shouldReturn($this);

--- a/src/Domain/Rule.php
+++ b/src/Domain/Rule.php
@@ -83,7 +83,7 @@ class Rule implements RuleInterface
         $matchingNodes = array_filter($nodes, function (NodeInterface $node) {
             return $this->matches($node);
         });
-        
+
         if ([] === $matchingNodes) {
             return [];
         }

--- a/src/Domain/Rule.php
+++ b/src/Domain/Rule.php
@@ -83,6 +83,10 @@ class Rule implements RuleInterface
         $matchingNodes = array_filter($nodes, function (NodeInterface $node) {
             return $this->matches($node);
         });
+        
+        if ([] === $matchingNodes) {
+            return [];
+        }
 
         return array_filter($this->requirements, function (string $requirement) use ($matchingNodes) {
             if ($this->subject === $requirement) {

--- a/src/RuleBuilder.php
+++ b/src/RuleBuilder.php
@@ -52,10 +52,6 @@ class RuleBuilder
 
     public function in(string $subject): RuleInterface
     {
-        if (empty($this->requirements)) {
-            throw new \Exception('Can not create a rule without any requirement defined previously.');
-        }
-
         if (null === $this->type) {
             throw new \Exception('Can not create a rule without any type defined previously.');
         }


### PR DESCRIPTION
When you define a rule, you define the path where you have to check the rules.
If there is no matching file, all the dependencies are marked as "unused".
This PR will skip a rule if there is no matching file.

This PR allows to define a rule without any requirements (for example, a well defined Domain has never any requirement)